### PR TITLE
use fa icons

### DIFF
--- a/bootstrap3/fabrik-modal.php
+++ b/bootstrap3/fabrik-modal.php
@@ -31,11 +31,11 @@ $footer = isset($d->footer) ? $d->footer : '';
 		</h3>
 		<?php if (!$d->modal && $d->expandable !== false) : ?>
 			<a class="expand" href="#" data-role="expand">
-				<span class="icon-full-screen icon-expand"></span>
+				<span class="fa fa-expand"></span>
 			</a>
 		<?php endif; ?>
 		<a href="#" class="closeFabWin" data-role="close">
-			<span class="icon-cancel icon-remove-sign"></span>
+			<span class="fa fa-times"></span>
 		</a>
 	</div>
 	<div class="contentWrapper">


### PR DESCRIPTION
it seems it's not going through fabrik-icon.php
http://fabrikar.com/forums/index.php?threads/more-purity-iii-woes.48936/

Additionally for the old "menu item vanishing on hover":
it's a purityIII bug, not only Fabrik but in any menu beside PurityIII mega menu: color is set to #FFF on li.open (.open is addes via JS by the template on hover)
So it needs some CSS, e.g.
.nav .open >a:hover, .nav .open >a {
    color: inherit;
}
